### PR TITLE
Update env.web to include www subdomain placeholder

### DIFF
--- a/env.web
+++ b/env.web
@@ -17,7 +17,7 @@ ALLOWED_HOST=*
 # The Nginx (web server) proxy needs to know what hostname to listen for, and what
 # port to forward those requests to.  So, enter the hostnome at which your site will
 # be accessed here.  You probably will not need to change the port number.
-VIRTUAL_HOST=yourdomain.com
+VIRTUAL_HOST=yourdomain.com,www.yourdomain.com
 VIRTUAL_PORT=8000
 
 # If you are using LetsEncrypt for SSL certificate generation,


### PR DESCRIPTION
See https://github.com/django-danceschool/django-danceschool/issues/117.

A placeholder for the `www` subdomain exists in the LetsEncrypt configuration section, but not nginx. This creates some ambiguity as it's not immediately obvious you need to manually add it yourself given the precedent of simply editing the existing placeholder variables.

It's a small detail but should help someone avoid running into the same basic problem I did.