### PR TITLE
Clarify configuration options for email set-up

### DIFF
--- a/env.default
+++ b/env.default
@@ -29,7 +29,7 @@ TIME_ZONE=America/New_York
 # If you wish to use a service such as Gmail to send emails, then you will want to uncomment
 # this line and fill in the email URL here.
 # e.g. for Gmail "smtp://yourgmailaccount:yourpassword@smtp.gmail.com:587/?tls=True"
-# for Sendgrid "smtp://yoursendgridaccount:yourpassword@smtp.sendgrid.com:587/?tls=True"
+# for Sendgrid "smtp://USERNAME:PASSWORD@smtp.sendgrid.com:587/?tls=True"
 # EMAIL_URL=smtp://yourgmailaccount:yourpassword@smtp.gmail.com:587/?tls=True
 
 # If you are using Paypal, then you will need to uncomment the following lines and

--- a/school/settings.py
+++ b/school/settings.py
@@ -414,9 +414,8 @@ STRIPE_PRIVATE_KEY = environ.get('STRIPE_PRIVATE_KEY')
 if STRIPE_PUBLIC_KEY and STRIPE_PRIVATE_KEY:
     INSTALLED_APPS.append('danceschool.payments.stripe')
 
-# Set Email using dj_email_url which parses $EMAIL_URL.
-# Note: Sendgrid has been removed becuase of API issues; use
-# SMTP integration for Sendgrid.
+# This configures email through dj_email_url by parsing $EMAIL_URL, which is
+# set in env.default. Sendgrid and Gmail both use SMTP.
 if 'EMAIL_URL' in environ:
     email_config = dj_email_url.config()
     EMAIL_FILE_PATH = email_config.get('EMAIL_FILE_PATH')


### PR DESCRIPTION
This modifies the text explaining how emails are configured in
settings.py while also changing the placeholder values found in
env.default to make it more explicitly obvious what you need to write.

Otherwise someone might unknowingly be using an email address as a
username instead of the username attached to the account and are
subsequently assaulted by a bunch of errors which do nothing to indicate
this fact.

Not that I'm talking from personal experience.