### PR TITLE
fix variable mismatch that checked for user, but deleted password

### DIFF
--- a/docker/setup_stack.sh
+++ b/docker/setup_stack.sh
@@ -85,7 +85,7 @@ check_postgres_secrets () {
         if [ $POSTGRES_USER_EXISTS -ge 1 ] ; then
             docker secret rm postgres_user
         fi
-        if [ $POSTGRES_USER_EXISTS -ge 1 ] ; then
+        if [ $POSTGRES_PASSWORD_EXISTS -ge 1 ] ; then
             docker secret rm postgres_password
         fi
         if [ $POSTGRES_URL_EXISTS -ge 1 ] ; then


### PR DESCRIPTION
the script checked if the POSTGRES_USER existed, but deleted the password if failed